### PR TITLE
Allow operation chaining to continue after pushing operator/operand.

### DIFF
--- a/Calculator/Calculator/MCACalculator.m
+++ b/Calculator/Calculator/MCACalculator.m
@@ -43,7 +43,7 @@
     
     if (previousOperator && previousOperator.precedence >= operator.precedence) {
         // expression can be simplified
-        retObj = [self evaluateExpressionFromHistory];
+        retObj = [self simplifyOperators:[self.operators mutableCopy] forOperands:[self.operands mutableCopy]];
         // keep the result and the most recent operation
         self.operands = [NSMutableArray arrayWithObjects:retObj, nil];
         self.operators = [NSMutableArray arrayWithObjects:[self.operators lastObject], nil];

--- a/Calculator/CalculatorTests/untitled folder/MCACalculatorTests.m
+++ b/Calculator/CalculatorTests/untitled folder/MCACalculatorTests.m
@@ -126,4 +126,26 @@
     XCTAssertTrue(expressionComplete, @"Expected evaluating expression to set expression complete to YES.");
 }
 
+- (void)testMCACalculator_pushOperatorWithOperand_shouldNotSetExpressionComplete
+{
+    // Arrange
+    self.calculator.expressionComplete = NO;
+    
+    MCAOperator *highPrecedenceOperator = [[MCAOperator alloc] initWithPrecedence:10 operationBlock:^NSDecimalNumber * _Nonnull(NSDecimalNumber * _Nonnull operand1, NSDecimalNumber * _Nonnull operand2) {
+        return [NSDecimalNumber zero];
+    }];
+    
+    MCAOperator *lowPrecendenceOperator = [[MCAOperator alloc] initWithPrecedence:5 operationBlock:^NSDecimalNumber * _Nonnull(NSDecimalNumber * _Nonnull operand1, NSDecimalNumber * _Nonnull operand2) {
+        return [NSDecimalNumber zero];
+    }];
+    
+    self.calculator.operators = [NSMutableArray arrayWithObjects:highPrecedenceOperator, nil];
+    [self.calculator pushOperator:lowPrecendenceOperator withOperand:[NSDecimalNumber one]];
+    
+    // Act
+    BOOL expressionComplete = self.calculator.isExpressionComplete;
+    
+    //Assert
+    XCTAssertFalse(expressionComplete, @"Expected push operand with operator to not set expression complete.");
+}
 @end


### PR DESCRIPTION
Fixes issue where expression was set to complete after pushing an operator with an operand.