### PR TITLE
Improved WolframAlpha Query Encoding

### DIFF
--- a/Calculator/Calculator/Main.storyboard
+++ b/Calculator/Calculator/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -28,6 +28,8 @@
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.34999999999999998" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BDf-dj-ie2">
                                                 <rect key="frame" x="16" y="0.0" width="568" height="75"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="right" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="BDf-dj-ie2">
+                                                <rect key="frame" x="16" y="0.0" width="568" height="91"/>
                                                 <fontDescription key="fontDescription" type="system" weight="ultraLight" pointSize="76"/>
                                                 <color key="textColor" name="alternateSelectedControlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <nil key="highlightedColor"/>
@@ -37,9 +39,15 @@
                                         <constraints>
                                             <constraint firstItem="BDf-dj-ie2" firstAttribute="leading" secondItem="GMb-Dn-vbV" secondAttribute="leading" constant="16" id="2z3-C1-75b"/>
                                             <constraint firstAttribute="trailing" secondItem="BDf-dj-ie2" secondAttribute="trailing" constant="16" id="IxG-Rd-Di2"/>
-                                            <constraint firstItem="BDf-dj-ie2" firstAttribute="top" relation="greaterThanOrEqual" secondItem="GMb-Dn-vbV" secondAttribute="top" id="LIO-ah-6Wf"/>
+                                            <constraint firstItem="BDf-dj-ie2" firstAttribute="top" secondItem="GMb-Dn-vbV" secondAttribute="top" id="LIO-ah-6Wf"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="YSf-HS-cV0"/>
                                             <constraint firstAttribute="bottom" secondItem="BDf-dj-ie2" secondAttribute="bottom" id="Zzv-Ok-wIs"/>
                                         </constraints>
+                                        <variation key="default">
+                                            <mask key="constraints">
+                                                <exclude reference="YSf-HS-cV0"/>
+                                            </mask>
+                                        </variation>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="Kpf-6K-CHP">
                                         <rect key="frame" x="0.0" y="77" width="600" height="75"/>
@@ -143,7 +151,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oyX-g5-mzz" userLabel="Multiply">
-                                                <rect key="frame" x="452" y="0.0" width="149" height="75"/>
+                                                <rect key="frame" x="451" y="0.0" width="148.5" height="72.5"/>
                                                 <color key="backgroundColor" red="0.98431372549999996" green="0.72156862749999995" blue="0.18823529410000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="42"/>
                                                 <state key="normal" title="×">
@@ -330,6 +338,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="xBd-Ug-S8N" firstAttribute="height" secondItem="kEa-uj-pCW" secondAttribute="height" id="AMn-dM-GQA"/>
+                                    <constraint firstItem="GMb-Dn-vbV" firstAttribute="height" relation="greaterThanOrEqual" secondItem="Kpf-6K-CHP" secondAttribute="height" id="K7o-Wj-LZF"/>
                                     <constraint firstItem="kEa-uj-pCW" firstAttribute="height" secondItem="Kpf-6K-CHP" secondAttribute="height" id="MzS-cD-2j6"/>
                                     <constraint firstItem="Kpf-6K-CHP" firstAttribute="width" secondItem="xQK-pD-ml5" secondAttribute="width" id="RYU-Z5-YGC"/>
                                     <constraint firstItem="UFq-1H-yHP" firstAttribute="width" secondItem="oyX-g5-mzz" secondAttribute="width" id="fog-Dz-rAB"/>

--- a/Calculator/Calculator/Main.storyboard
+++ b/Calculator/Calculator/Main.storyboard
@@ -23,12 +23,10 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="xQK-pD-ml5">
                                 <rect key="frame" x="0.0" y="64" width="600" height="536"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GMb-Dn-vbV">
+                                    <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="GMb-Dn-vbV">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="75"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.34999999999999998" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BDf-dj-ie2">
-                                                <rect key="frame" x="16" y="0.0" width="568" height="75"/>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="0" textAlignment="right" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="BDf-dj-ie2">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" misplaced="YES" text="0" textAlignment="right" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="BDf-dj-ie2">
                                                 <rect key="frame" x="16" y="0.0" width="568" height="91"/>
                                                 <fontDescription key="fontDescription" type="system" weight="ultraLight" pointSize="76"/>
                                                 <color key="textColor" name="alternateSelectedControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -151,7 +149,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oyX-g5-mzz" userLabel="Multiply">
-                                                <rect key="frame" x="451" y="0.0" width="148.5" height="72.5"/>
+                                                <rect key="frame" x="452" y="0.0" width="149" height="75"/>
                                                 <color key="backgroundColor" red="0.98431372549999996" green="0.72156862749999995" blue="0.18823529410000001" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="42"/>
                                                 <state key="normal" title="×">

--- a/Calculator/Calculator/Wolfram Alpha/MCAWolframAlphaQuery.m
+++ b/Calculator/Calculator/Wolfram Alpha/MCAWolframAlphaQuery.m
@@ -28,7 +28,9 @@ NSString * const wolframAlphaQueryString = @"http://api.wolframalpha.com/v2/quer
     }
     
     if (self = [super init]) {
-        _query = [query stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+        NSMutableCharacterSet *URLQueryPartAllowedCharacterSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+        [URLQueryPartAllowedCharacterSet removeCharactersInString:@"#$&+,/:;=?@[]"]; // escape all characters WolframAlpha API does not accept in query
+        _query = [query stringByAddingPercentEncodingWithAllowedCharacters:URLQueryPartAllowedCharacterSet];
     }
     return self;
 }

--- a/Calculator/CalculatorTests/MCAWolframAlphaQueryTests.m
+++ b/Calculator/CalculatorTests/MCAWolframAlphaQueryTests.m
@@ -28,6 +28,16 @@
     XCTAssertNotNil(query.queryURL);
 }
 
+- (void)testWolframURLEscaping {
+    NSString *queryString = @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_.~!#$&'()*+,/:;=?@[]";
+    NSString *expected = @"http://api.wolframalpha.com/v2/query?input=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_.~!%23%24%26'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D&appid=7455XJ-6VH386Y4Y4&format=plaintext";
+    
+    MCAWolframAlphaQuery *query = [[MCAWolframAlphaQuery alloc] initWithQueryText:queryString];
+    NSString *result = [query.queryURL absoluteString];
+    
+    XCTAssertTrue([expected isEqualToString:result]);
+}
+
 - (void)testURLEncoding {
     NSString *eulerQuery = @"euler's law";
     MCAWolframAlphaQuery *query = [[MCAWolframAlphaQuery alloc] initWithQueryText:eulerQuery];


### PR DESCRIPTION
Added additional percent encoding to MCAWolframAlphaQuery to match what Wolfram Alpha API expects, e.g. encode all characters except alphanumeric and -_.~!()*'. 
Example: Before, entering 9 + 2 would return 9x2 from WolframAlpha because it wasn't properly encoding the + symbol.

Created additional testWolframURLEscaping XCTest to verify all characters are properly escaped.

Modified UI constraints so that result cell is not partially hidden when the phone goes into Landscape mode.
![orientationchange](https://cloud.githubusercontent.com/assets/20425743/18451027/64afcc92-7903-11e6-84e4-42a9a96d2342.gif)
